### PR TITLE
Supporting sonic-vlan yang

### DIFF
--- a/docker/build-mgmt-framework.Dockerfile
+++ b/docker/build-mgmt-framework.Dockerfile
@@ -6,10 +6,9 @@ apt update && apt install -qy make autotools-dev autoconf dh-exec debhelper libt
 
 # remove libyang plugin library since debian package is broken
 # TODO fix this
-
 RUN --mount=type=tmpfs,target=/src cd /src && git clone https://github.com/CESNET/libyang.git && \
             sed -i -e '/usr\/lib\/\*\/libyang1/d' libyang/packages/debian.libyang.install && \
-            cmake /src/libyang && make build-deb && cp -r debs/*.deb /tmp/ && make install
+            cmake /src/libyang && make build-deb && cp -r debs/*.deb /tmp/ && make install && ldconfig
 
 RUN --mount=type=tmpfs,target=/tmp cd /tmp && wget -O go.tar.gz https://golang.org/dl/go1.14.4.linux-amd64.tar.gz && tar -C /usr/local -xzf go.tar.gz
 

--- a/docker/build-mgmt-framework.Dockerfile
+++ b/docker/build-mgmt-framework.Dockerfile
@@ -2,10 +2,11 @@
 FROM debian:buster as builder
 
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
-apt update && apt install -qy make autotools-dev autoconf dh-exec debhelper libtool pkg-config m4 libxml2-utils xsltproc python-lxml libexpat1-dev python rsync wget default-jdk libxml2-dev git cmake gcc libpcre3-dev python-pip quilt python3 python3-pip devscripts
+apt update && apt install -qy make autotools-dev autoconf dh-exec debhelper libtool pkg-config m4 libxml2-utils xsltproc python-lxml libexpat1-dev python rsync wget default-jdk libxml2-dev git cmake gcc libpcre3-dev python-pip quilt python3 python3-pip devscripts doxygen libcmocka-dev
 
 # remove libyang plugin library since debian package is broken
 # TODO fix this
+
 RUN --mount=type=tmpfs,target=/src cd /src && git clone https://github.com/CESNET/libyang.git && \
             sed -i -e '/usr\/lib\/\*\/libyang1/d' libyang/packages/debian.libyang.install && \
             cmake /src/libyang && make build-deb && cp -r debs/*.deb /tmp/ && make install

--- a/docker/build-mgmt-framework.Dockerfile
+++ b/docker/build-mgmt-framework.Dockerfile
@@ -7,8 +7,9 @@ apt update && apt install -qy make autotools-dev autoconf dh-exec debhelper libt
 # remove libyang plugin library since debian package is broken
 # TODO fix this
 RUN --mount=type=tmpfs,target=/src cd /src && git clone https://github.com/CESNET/libyang.git && \
+            cd libyang && git checkout 875bcf800730a9a0ec155ffe19e176d6711655ff && cd .. && \
             sed -i -e '/usr\/lib\/\*\/libyang1/d' libyang/packages/debian.libyang.install && \
-            cmake /src/libyang && make build-deb && cp -r debs/*.deb /tmp/ && make install && ldconfig
+            cmake /src/libyang && make build-deb && cp -r debs/*.deb /tmp/ && make install
 
 RUN --mount=type=tmpfs,target=/tmp cd /tmp && wget -O go.tar.gz https://golang.org/dl/go1.14.4.linux-amd64.tar.gz && tar -C /usr/local -xzf go.tar.gz
 

--- a/patches/mgmt/sonic_vlan.patch
+++ b/patches/mgmt/sonic_vlan.patch
@@ -1,0 +1,192 @@
+diff -Naur usonic/sm/sonic-mgmt-common/models/yang/sonic/sonic-portchannel.yang usonic/sm/sonic-mgmt-common/models/yang/sonic/sonic-portchannel.yang
+--- usonic/sm/sonic-mgmt-common/models/yang/sonic/sonic-portchannel.yang	1969-12-31 19:00:00.000000000 -0500
++++ usonic/sm/sonic-mgmt-common/models/yang/sonic/sonic-portchannel.yang	2020-08-10 00:38:44.013335171 -0400
+@@ -0,0 +1,77 @@
++module sonic-portchannel {
++	namespace "http://github.com/Azure/sonic-portchannel";
++	prefix spc;
++
++	import sonic-common {
++		prefix scommon;
++	}
++
++	import sonic-port {
++		prefix prt;
++	}
++
++	organization
++		"SONiC";
++
++	contact
++		"SONiC";
++
++	description
++		"SONIC PORTCHANNEL";
++
++	revision 2019-05-15 {
++		description
++			"Initial revision.";
++	}
++
++	container sonic-portchannel {
++
++		container PORTCHANNEL {
++
++			list PORTCHANNEL_LIST {
++				key "name";
++
++				max-elements 3;
++
++				leaf name {
++					type string;
++				}
++
++				leaf admin_status {
++					type scommon:admin-status;
++				}
++
++				leaf mtu {
++					type uint16;
++				}
++
++				leaf min_links {
++					type uint8;
++				}
++
++				leaf fallback {
++					type boolean;
++				}
++			}
++		}
++
++		container PORTCHANNEL_MEMBER { 
++
++			list PORTCHANNEL_MEMBER_LIST { 
++				key "name ifname";
++
++				leaf name {
++					type leafref {
++						path "../../../PORTCHANNEL/PORTCHANNEL_LIST/name";
++					}
++				}
++
++				leaf ifname {
++					type leafref {
++						path "/prt:sonic-port/prt:PORT/prt:PORT_LIST/prt:ifname";
++					}
++				}
++			}
++		}
++	}
++}
+diff -Naur usonic/sm/sonic-mgmt-common/models/yang/sonic/sonic-vlan.yang usonic/sm/sonic-mgmt-common/models/yang/sonic/sonic-vlan.yang
+--- usonic/sm/sonic-mgmt-common/models/yang/sonic/sonic-vlan.yang	1969-12-31 19:00:00.000000000 -0500
++++ usonic/sm/sonic-mgmt-common/models/yang/sonic/sonic-vlan.yang	2020-08-10 00:38:33.845362834 -0400
+@@ -0,0 +1,107 @@
++module sonic-vlan {
++	namespace "http://github.com/Azure/sonic-vlan";
++	prefix svlan;
++	yang-version 1.1;
++
++	import sonic-common {
++		prefix scommon;
++	}
++
++	import sonic-port {
++		prefix prt;
++	}
++
++	import sonic-portchannel {
++		prefix spc;
++	}
++
++	organization
++		"SONiC";
++
++	contact
++		"SONiC";
++
++	description
++		"SONIC VLAN";
++
++	revision 2019-05-15 {
++		description
++			"Initial revision.";
++	}
++
++
++	container sonic-vlan {
++
++		container VLAN { 
++
++			list VLAN_LIST { 
++				key "name";
++				must "./name = concat('Vlan', string(./vlanid))"{
++					error-app-tag vlan-invalid;
++				}
++
++				leaf name {
++					type string {
++						pattern "Vlan(409[0-5]|40[0-8][0-9]|[1-3][0-9]{3}|[1-9][0-9]{2}|[1-9][0-9]|[1-9])" {
++							error-message "Invalid Vlan name pattern";
++							error-app-tag vlan-name-invalid;
++						}
++					}
++				}
++
++				leaf vlanid {
++					mandatory true;
++					type uint16 {
++						range "1..4095" {
++							error-message "Vlan ID out of range";
++							error-app-tag vlanid-invalid;
++						}
++					}
++				}
++
++				leaf-list members {
++					 must "count(../members[text()=/spc:sonic-portchannel/spc:PORTCHANNEL_MEMBER/" +
++					      "spc:PORTCHANNEL_MEMBER_LIST[spc:ifname=current()]/spc:name]) = 0 and " +
++					      "count(../members[text()=/spc:sonic-portchannel/spc:PORTCHANNEL_MEMBER/" +
++					      "spc:PORTCHANNEL_MEMBER_LIST[spc:name=current()]/spc:ifname]) = 0 " {
++					       error-message "A vlan interface member cannot be part of portchannel which is already a vlan member";
++					}
++
++
++					type union {
++						type leafref {
++							path "/prt:sonic-port/prt:PORT/prt:PORT_LIST/prt:ifname";
++						}
++						type leafref {
++							path "/spc:sonic-portchannel/spc:PORTCHANNEL/spc:PORTCHANNEL_LIST/spc:name";
++						}
++					}
++				}
++			}
++		}
++
++		container VLAN_MEMBER { 
++
++			list VLAN_MEMBER_LIST { 
++				key "name ifname";
++
++				leaf name {
++					type leafref {
++						path "../../../VLAN/VLAN_LIST/name";
++					}
++				}
++
++				leaf ifname {
++					type leafref {
++						path "/prt:sonic-port/prt:PORT/prt:PORT_LIST/prt:ifname";
++					}
++				}
++
++				leaf tagging_mode {
++					type scommon:tagging_mode;
++					default tagged;
++				}
++			}
++		}
++	}
++}


### PR DESCRIPTION
By default sonic-mgmt-common doesn't support sonic-vlan YANG model.
But we cannot reference from the latest sonic-buildimage repo as the YANG version is not compatible with existing sonic-port YANG model. 
Link: https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/yang-models/sonic-vlan.yang

So we have applied the compatible version of sonic-vlan yang file as a patch.