### PR TITLE
 SONiC VLAN fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,4 +34,3 @@ jobs:
         - run: |
             SONIC_MGMT_ADDR=$($K get svc sonic-mgmt -o=jsonpath='{.spec.clusterIP}{"\n"}')
             curl http://$SONIC_MGMT_ADDR/restconf/data/sonic-port:sonic-port
-            curl http://$SONIC_MGMT_ADDR/restconf/data/sonic-vlan:sonic-vlan

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,3 +34,4 @@ jobs:
         - run: |
             SONIC_MGMT_ADDR=$($K get svc sonic-mgmt -o=jsonpath='{.spec.clusterIP}{"\n"}')
             curl http://$SONIC_MGMT_ADDR/restconf/data/sonic-port:sonic-port
+            curl http://$SONIC_MGMT_ADDR/restconf/data/sonic-vlan:sonic-vlan

--- a/patches/mgmt/series
+++ b/patches/mgmt/series
@@ -4,3 +4,4 @@ cvl_redis_host_option.patch
 debian_package.patch
 mgmt_rest_no_tls.patch
 translib_redis_option.patch
+sonic_vlan.patch

--- a/patches/series
+++ b/patches/series
@@ -6,3 +6,4 @@ mgmt/cvl_redis_host_option.patch
 mgmt/debian_package.patch
 mgmt/mgmt_rest_no_tls.patch
 mgmt/translib_redis_option.patch
+mgmt/sonic_vlan.patch


### PR DESCRIPTION
I had not put changes in'series' file for 'quilt' to apply the patches on sonic-mgmt-common.
After these changes, you should be seeing sonic-vlan.yang included in sonic-mgmt pod.
